### PR TITLE
Improve registration form with validation and conditional field

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -2,9 +2,20 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
+from django.utils.translation import gettext_lazy as _
 from .models import CustomUser
 
 class RegistrationForm(UserCreationForm):
+    username = forms.CharField(
+        max_length=30,
+        help_text="Required. 30 characters or fewer. Letters, digits and underscores only.",
+        validators=[RegexValidator(
+            regex=r"^[A-Za-z0-9_]+$",
+            message=_("Username may contain only letters, digits and underscores."),
+        )],
+        error_messages={"max_length": _("Username may be up to 30 characters long.")},
+    )
     role = forms.ChoiceField(choices=CustomUser.RoleChoices.choices)
     secret_key = forms.CharField(required=False, help_text="Required if registering as manager.")
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -5,12 +5,33 @@
 <div class="container mt-5">
     <h2 class="text-center">Регистрация</h2>
 
-    <form method="post" class="mt-4 w-50 mx-auto border rounded p-4 shadow">
+    <form method="post" class="mt-4 w-50 mx-auto border rounded p-4 shadow" id="registration-form">
         {% csrf_token %}
         {{ form.as_p }}
 
         <button type="submit" class="btn btn-primary w-100">Регистрирай се</button>
     </form>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const roleSelect = document.getElementById('id_role');
+    const secretKeyInput = document.getElementById('id_secret_key');
+    if (!roleSelect || !secretKeyInput) {
+        return;
+    }
+    const secretKeyField = secretKeyInput.parentElement;
+    function toggleSecretKey() {
+        if (roleSelect.value === 'manager') {
+            secretKeyField.style.display = '';
+        } else {
+            secretKeyField.style.display = 'none';
+            secretKeyInput.value = '';
+        }
+    }
+    roleSelect.addEventListener('change', toggleSecretKey);
+    toggleSecretKey();
+});
+</script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- use regex and max length for `username`
- hide `secret_key` field unless role is manager

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6887b969fa3c83288da19cf1006da86b