### PR TITLE
Fix admin role editing

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from .forms import CustomUserChangeForm, CustomUserCreationForm
 
 from .models import CustomUser
 
@@ -7,19 +8,34 @@ from .models import CustomUser
 @admin.register(CustomUser)
 class CustomUserAdmin(UserAdmin):
     model = CustomUser
+    add_form = CustomUserCreationForm
+    form = CustomUserChangeForm
 
     list_display = ("username", "role", "is_staff", "is_active")
     list_filter = ("role", "is_staff", "is_active")
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         ("Personal Info", {"fields": ("role",)}),
-        ("Permissions", {"fields": ("is_staff", "is_active", "groups", "user_permissions")}),
+        (
+            "Permissions",
+            {"fields": ("is_staff", "is_active", "groups", "user_permissions")},
+        ),
     )
     add_fieldsets = (
-        (None, {
-            "classes": ("wide",),
-            "fields": ("username", "role", "password1", "password2", "is_staff", "is_active"),
-        }),
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "username",
+                    "role",
+                    "password1",
+                    "password2",
+                    "is_staff",
+                    "is_active",
+                ),
+            },
+        ),
     )
     search_fields = ("username",)
     ordering = ("username",)

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,33 +1,57 @@
 from django import forms
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _
 from .models import CustomUser
 
+
 class RegistrationForm(UserCreationForm):
     username = forms.CharField(
         max_length=30,
         help_text="Required. 30 characters or fewer. Letters, digits and underscores only.",
-        validators=[RegexValidator(
-            regex=r"^[A-Za-z0-9_]+$",
-            message=_("Username may contain only letters, digits and underscores."),
-        )],
+        validators=[
+            RegexValidator(
+                regex=r"^[A-Za-z0-9_]+$",
+                message=_("Username may contain only letters, digits and underscores."),
+            )
+        ],
         error_messages={"max_length": _("Username may be up to 30 characters long.")},
     )
     role = forms.ChoiceField(choices=CustomUser.RoleChoices.choices)
-    secret_key = forms.CharField(required=False, help_text="Required if registering as manager.")
+    secret_key = forms.CharField(
+        required=False, help_text="Required if registering as manager."
+    )
 
     class Meta:
         model = CustomUser
-        fields = ('username', 'password1', 'password2', 'role', 'secret_key')
+        fields = ("username", "password1", "password2", "role", "secret_key")
 
     def clean(self):
         cleaned_data = super().clean()
-        role = cleaned_data.get('role')
-        secret_key = cleaned_data.get('secret_key')
+        role = cleaned_data.get("role")
+        secret_key = cleaned_data.get("secret_key")
 
-        if role == CustomUser.RoleChoices.MANAGER and secret_key != settings.MANAGER_SECRET_KEY:
+        if (
+            role == CustomUser.RoleChoices.MANAGER
+            and secret_key != settings.MANAGER_SECRET_KEY
+        ):
             raise ValidationError("Invalid secret key for manager registration.")
         return cleaned_data
+
+
+class CustomUserCreationForm(UserCreationForm):
+    """Admin form for creating users with a role."""
+
+    class Meta(UserCreationForm.Meta):
+        model = CustomUser
+        fields = UserCreationForm.Meta.fields + ("role",)
+
+
+class CustomUserChangeForm(UserChangeForm):
+    """Admin form for updating users with the role field."""
+
+    class Meta(UserChangeForm.Meta):
+        model = CustomUser
+        fields = "__all__"


### PR DESCRIPTION
## Summary
- allow editing `role` in Django admin
- add custom user forms for admin

## Testing
- `python manage.py check`
- `black accounts/forms.py accounts/admin.py --check`


------
https://chatgpt.com/codex/tasks/task_e_688a770826548328ae94a19676e8b23e