### PR TITLE
fix: ensure default avatar path

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 
 class CustomUser(AbstractUser):
@@ -13,6 +12,6 @@ class CustomUser(AbstractUser):
         default=RoleChoices.WORKER,
     )
     profile_picture = models.URLField(
-        default=settings.DEFAULT_AVATAR_URL,
+        default="/static/icons/default_avatar.svg",
     )
 


### PR DESCRIPTION
## Summary
- point CustomUser.profile_picture to default avatar under `/static/icons/default_avatar.svg`

## Testing
- `python manage.py makemigrations`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890baba817c8328a28e18f38101a967