### PR TITLE
Adjust navbar layout and interactive styles

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,11 +1,22 @@
 body {
-  background-color: #f5f6fa;
+  background-color: #eef3f9;
   font-family: 'Inter', sans-serif;
 }
 
 .navbar {
   background-color: #ffffff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  height: 80px;
+  padding: 0 1rem;
+}
+
+.navbar .container-fluid {
+  height: 100%;
+}
+
+.navbar .btn {
+  display: flex;
+  align-items: center;
 }
 
 .navbar-brand {
@@ -18,13 +29,14 @@ body {
 }
 
 .icon {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
+  vertical-align: middle;
 }
 
 .profile-pic {
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   object-fit: cover;
 }
@@ -52,12 +64,13 @@ body {
 }
 
 .btn {
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.2s ease;
 }
 
 .btn:hover {
   cursor: pointer;
   filter: brightness(0.95);
+  transform: scale(1.05);
 }
 
 


### PR DESCRIPTION
## Summary
- Raise navbar height to 80px and align buttons, icons, and profile images
- Soften page background color
- Add scaling hover effect for buttons

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890d3ed5ec08328ae9e8e274dd59d23