### PR TITLE
Fix header avatar fallback

### DIFF
--- a/common/context_processors.py
+++ b/common/context_processors.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+
+def default_avatar(request):
+    """Provide DEFAULT_AVATAR_URL to all templates."""
+    return {"DEFAULT_AVATAR_URL": settings.DEFAULT_AVATAR_URL}

--- a/config/settings.py
+++ b/config/settings.py
@@ -69,6 +69,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'common.context_processors.default_avatar',
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,7 @@
     </a>
     <div class="ms-auto d-flex align-items-center">
       {% if user.is_authenticated %}
-        <img src="{{ user.profile_picture }}" alt="Avatar" class="profile-pic rounded-circle me-2" title="{{ user.username }}">
+        <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic rounded-circle me-2" title="{{ user.username }}" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
         <span class="me-3">{{ user.username }}</span>
         <a class="btn btn-outline-secondary btn-sm d-flex align-items-center me-2" href="{% url 'edit_profile' %}">
           <img src="{% static 'icons/edit.svg' %}" class="icon me-1" alt="Edit"> Edit Profile


### PR DESCRIPTION
## Summary
- Add template context processor to expose `DEFAULT_AVATAR_URL`
- Use default avatar in navbar with image load fallback

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6890d73db6a08328bf7fe81864cde37c