### PR TITLE
Add page titles and favicon

### DIFF
--- a/static/icons/favicon.svg
+++ b/static/icons/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="#0d6efd">
+  <path d="M4 44h56v16H4z"/>
+  <path d="M12 28l8 8V20l12 8V12l24 16v32H4V28z"/>
+</svg>

--- a/templates/accounts/delete_account.html
+++ b/templates/accounts/delete_account.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Delete Account - FactoryApp{% endblock %}
+
 {% block content %}
 <div class="container mt-5 d-flex justify-content-center">
     <div class="card-style text-center">

--- a/templates/accounts/edit_profile.html
+++ b/templates/accounts/edit_profile.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Edit Profile - FactoryApp{% endblock %}
+
 {% block content %}
 <div class="container mt-5">
     <h2 class="text-center mb-4">Edit Profile</h2>

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Login - FactoryApp{% endblock %}
+
 {% block content %}
 <div class="container mt-5">
     <h2 class="text-center mb-4">Login</h2>

--- a/templates/accounts/logout_confirm.html
+++ b/templates/accounts/logout_confirm.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Logout - FactoryApp{% endblock %}
+
 {% block content %}
 <div class="container mt-5 d-flex justify-content-center">
     <div class="card-style text-center">

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>FactoryApp</title>
+    <title>{% block title %}FactoryApp{% endblock %}</title>
+    <link rel="icon" href="{% static 'icons/favicon.svg' %}" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <!-- Bootstrap 5 CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% block title %}Home - FactoryApp{% endblock %}
+
 {% block content %}
   <div class="d-flex justify-content-center mt-5">
     <div class="card-style text-center">

--- a/templates/inspections/list.html
+++ b/templates/inspections/list.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% load static %}
 
+{% block title %}Inspections - FactoryApp{% endblock %}
+
 {% block content %}
 <h2>Inspections</h2>
 <div class="mb-4">

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,5 +1,8 @@
 {% extends 'base.html' %}
 {% load static %}
+
+{% block title %}Register - FactoryApp{% endblock %}
+
 {% block content %}
 
 <div class="container mt-5">

--- a/templates/suggestions/list.html
+++ b/templates/suggestions/list.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% load static %}
 
+{% block title %}Suggestions - FactoryApp{% endblock %}
+
 {% block content %}
 <h2>Suggestions</h2>
 <div class="mb-3">


### PR DESCRIPTION
## Summary
- allow per-page titles and add favicon link in base template
- add favicon asset
- set descriptive titles for pages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689102ae84b88328ad18b5d42f83e273