### PR TITLE
Add suggestion history section

### DIFF
--- a/suggestions/tests.py
+++ b/suggestions/tests.py
@@ -1,3 +1,24 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Suggestion
+
+
+User = get_user_model()
+
+
+class SuggestionHistoryTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="user1", password="pass")
+
+    def test_history_shows_message_when_empty(self):
+        self.client.login(username="user1", password="pass")
+        response = self.client.get(reverse("suggestion_history"))
+        self.assertContains(response, "user1 have not made any suggestions")
+
+    def test_history_shows_user_suggestions(self):
+        Suggestion.objects.create(text="Test suggestion", created_by=self.user)
+        self.client.login(username="user1", password="pass")
+        response = self.client.get(reverse("suggestion_history"))
+        self.assertContains(response, "Test suggestion")

--- a/suggestions/urls.py
+++ b/suggestions/urls.py
@@ -6,4 +6,5 @@ from . import views
 urlpatterns = [
     path("", views.suggestion_list, name="suggestion_list"),
     path("vote/<int:pk>/<str:vote>/", views.vote_suggestion, name="vote_suggestion"),
+    path("history/", views.suggestion_history, name="suggestion_history"),
 ]

--- a/suggestions/views.py
+++ b/suggestions/views.py
@@ -25,3 +25,9 @@ def vote_suggestion(request, pk, vote):
     suggestion.save()
     return redirect("suggestion_list")
 
+
+@login_required
+def suggestion_history(request):
+    suggestions = Suggestion.objects.filter(created_by=request.user).order_by("-created_at")
+    return render(request, "suggestions/history.html", {"suggestions": suggestions})
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,8 @@
     <!-- Bootstrap 5 CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Font Awesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
 </head>
 <body>
@@ -25,6 +27,11 @@
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="{% url 'suggestion_list' %}">
             <img src="{% static 'icons/lightbulb.svg' %}" class="icon me-2" alt="Suggestions"> Suggestions
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link d-flex align-items-center" href="{% url 'suggestion_history' %}">
+            <i class="fa-solid fa-clock-rotate-left me-2"></i> History
           </a>
         </li>
         {% if user.role == 'manager' %}

--- a/templates/suggestions/history.html
+++ b/templates/suggestions/history.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Suggestion History - FactoryApp{% endblock %}
+{% block content %}
+<h2>Suggestion History</h2>
+<div class="list-group">
+  {% if suggestions %}
+    {% for s in suggestions %}
+    <div class="card-style mb-3">
+      <p class="mb-1">{{ s.text }}</p>
+      <small class="text-muted">{{ s.created_at|date:'d.m.Y H:i' }}</small>
+    </div>
+    {% endfor %}
+  {% else %}
+    <p>{{ request.user.username }} have not made any suggestions.</p>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Font Awesome support and navigation link for suggestion history
- implement suggestion history view and template showing user suggestions or a message if none
- test suggestion history behavior

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68910b1b384c8328a4958659e87e8929