### PR TITLE
Enhance history layout and add profile view

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,7 @@ from .views import (
     LogoutConfirmView,
     EditProfileView,
     DeleteAccountView,
+    ProfileView,
 )
 
 urlpatterns = [
@@ -13,5 +14,6 @@ urlpatterns = [
     path('logout/confirm/', LogoutConfirmView.as_view(), name='logout_confirm'),
     path('logout/', LogoutView.as_view(next_page='/'), name='logout'),
     path('profile/edit/', EditProfileView.as_view(), name='edit_profile'),
+    path('profile/', ProfileView.as_view(), name='view_profile'),
     path('delete/', DeleteAccountView.as_view(), name='delete_account'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -45,3 +45,7 @@ class DeleteAccountView(LoginRequiredMixin, TemplateView):
     def post(self, request, *args, **kwargs):
         request.user.delete()
         return redirect('index')
+
+
+class ProfileView(LoginRequiredMixin, TemplateView):
+    template_name = 'accounts/profile.html'

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,6 +42,13 @@ body {
   object-fit: cover;
 }
 
+.profile-pic-large {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
 .profile-link {
   text-decoration: none;
   color: #333333;

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Profile - FactoryApp{% endblock %}
+{% block content %}
+<h1 class="text-center mb-4">Profile</h1>
+<div class="d-flex flex-column align-items-center">
+  <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic-large mb-3" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
+  <p><strong>Email:</strong> {{ user.email }}</p>
+  <p><strong>Role:</strong> {{ user.get_role_display }}</p>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,7 +47,7 @@
     <div class="ms-auto me-5 d-flex align-items-center">
       {% if user.is_authenticated %}
       <div class="dropdown profile-menu">
-        <a href="#" class="d-flex align-items-center profile-link" id="profileDropdown">
+        <a href="{% url 'view_profile' %}" class="d-flex align-items-center profile-link" id="profileDropdown">
           <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic me-2" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
           <span>{{ user.username }}</span>
         </a>

--- a/templates/suggestions/history.html
+++ b/templates/suggestions/history.html
@@ -1,17 +1,17 @@
 {% extends 'base.html' %}
 {% block title %}Suggestion History - FactoryApp{% endblock %}
 {% block content %}
-<h2>Suggestion History</h2>
+<h1 class="text-center mb-4">Suggestion History</h1>
 <div class="list-group">
   {% if suggestions %}
     {% for s in suggestions %}
-    <div class="card-style mb-3">
-      <p class="mb-1">{{ s.text }}</p>
+    <div class="card-style mb-3 text-center">
+      <p class="mb-1 fs-4">{{ s.text }}</p>
       <small class="text-muted">{{ s.created_at|date:'d.m.Y H:i' }}</small>
     </div>
     {% endfor %}
   {% else %}
-    <p>{{ request.user.username }} have not made any suggestions.</p>
+    <p class="text-center">{{ request.user.username }} have not made any suggestions.</p>
   {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Center and enlarge suggestion history header and messages
- Add profile page with enlarged avatar, email, and role
- Link navbar avatar to profile page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68910cda683c8328ace58be5f374350a