### PR TITLE
Improve hover effects and profile dropdown alignment

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -60,25 +60,39 @@ body {
   text-decoration: none;
   color: #333333;
   cursor: pointer;
+  transition: transform 0.2s ease;
 }
 
 .profile-link:hover {
   color: #333333;
   text-decoration: none;
+  transform: scale(1.1);
 }
 
 .profile-menu:hover .dropdown-menu {
   display: block;
 }
 
+.profile-menu {
+  position: relative;
+}
+
+.profile-menu .dropdown-menu {
+  top: 100%;
+  left: auto;
+  right: 0;
+}
+
 .navbar-nav .nav-link {
   color: #333333;
   padding: 10px 16px;
+  transition: transform 0.2s ease;
 }
 
 .navbar-nav .nav-link:hover {
   background-color: #f0f0f0;
   border-radius: 4px;
+  transform: scale(1.1);
 }
 
 .profile-dropdown {
@@ -89,10 +103,12 @@ body {
 
 .profile-dropdown .dropdown-item {
   padding: 10px 20px;
+  transition: transform 0.2s ease;
 }
 
 .profile-dropdown .dropdown-item:hover {
   background-color: #f0f0f0;
+  transform: scale(1.05);
 }
 
 .card-style {


### PR DESCRIPTION
## Summary
- scale profile and navigation links on hover
- anchor the profile dropdown so it fully displays within the navbar
- enlarge dropdown menu items on hover for consistent button behavior

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689129a58374832884f1ff761467c47b