### PR TITLE
Refine profile dropdown alignment and hover

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -46,7 +46,7 @@ body {
 }
 
 .profile-pic:hover {
-  transform: scale(1.1);
+  transform: scale(1.05);
 }
 
 .profile-pic-large {
@@ -66,7 +66,7 @@ body {
 .profile-link:hover {
   color: #333333;
   text-decoration: none;
-  transform: scale(1.1);
+  transform: scale(1.05);
 }
 
 .profile-menu:hover .dropdown-menu {
@@ -78,9 +78,9 @@ body {
 }
 
 .profile-menu .dropdown-menu {
-  top: 100%;
+  top: calc(100% + 2px);
   left: auto;
-  right: 0;
+  right: -5px;
 }
 
 .navbar-nav .nav-link {
@@ -108,7 +108,7 @@ body {
 
 .profile-dropdown .dropdown-item:hover {
   background-color: #f0f0f0;
-  transform: scale(1.05);
+  transform: scale(1.02);
 }
 
 .card-style {


### PR DESCRIPTION
## Summary
- Reduce hover scaling for avatar and profile link to keep dropdown within bounds.
- Offset profile dropdown slightly right and down with a small gap below the avatar.
- Soften dropdown item hover scaling for better fit.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68912cd389f483289614e67554b25c46