### PR TITLE
Restore icon color and fix profile dropdown hover

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -39,7 +39,7 @@ body {
   height: 24px;
   vertical-align: middle;
   font-size: 24px;
-  color: #000000;
+  color: #0d6efd;
 }
 
 .profile-pic {
@@ -83,9 +83,9 @@ body {
 }
 
 .profile-menu .dropdown-menu {
-  top: calc(100% + 2px);
+  top: 100%;
   left: auto;
-  right: -5px;
+  right: 0;
 }
 
 .navbar-nav .nav-link {


### PR DESCRIPTION
## Summary
- Return icons to their original blue hue
- Keep profile dropdown open by removing the hover gap

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891300ed7148328aabb75be6047b4f7