### PR TITLE
Color navbar brand icon blue

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -32,6 +32,7 @@ body {
 .brand-icon {
   font-size: 32px;
   line-height: 1;
+  color: #0d6efd;
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- Color the navbar brand icon using the app's primary blue while preserving text color

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891317ac7c08328b570dd3cd1bef5f8