### PR TITLE
Add inspection deletion option for managers

### DIFF
--- a/inspections/urls.py
+++ b/inspections/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.inspection_list, name='inspection_list'),
+    path('<int:pk>/delete/', views.InspectionDeleteView.as_view(), name='inspection_delete'),
 ]

--- a/inspections/views.py
+++ b/inspections/views.py
@@ -1,7 +1,8 @@
-from datetime import date
-
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.shortcuts import redirect, render
+from django.urls import reverse_lazy
+from django.views.generic import DeleteView
 
 from .models import Inspection
 
@@ -37,3 +38,15 @@ def inspection_list(request):
     ]
     context = {"inspections": inspections, "notifications": notifications}
     return render(request, "inspections/list.html", context)
+
+
+class InspectionDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
+    """Allow managers to delete their inspections."""
+
+    model = Inspection
+    success_url = reverse_lazy("inspection_list")
+    template_name = "inspections/delete.html"
+
+    def test_func(self):
+        user = self.request.user
+        return getattr(user, "role", None) == "manager" and self.get_object().created_by == user

--- a/templates/inspections/delete.html
+++ b/templates/inspections/delete.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block title %}Delete Inspection - FactoryApp{% endblock %}
+
+{% block content %}
+<div class="container mt-5 d-flex justify-content-center">
+    <div class="card-style text-center">
+        <h2 class="mb-3">Delete Inspection</h2>
+        <p>Are you sure you want to delete "{{ object.title }}"?</p>
+        <form method="post" class="d-inline">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger">Yes, delete</button>
+        </form>
+        <a href="{% url 'inspection_list' %}" class="btn btn-secondary ms-2">Cancel</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/inspections/list.html
+++ b/templates/inspections/list.html
@@ -28,6 +28,9 @@
       <th>Description</th>
       <th>Due date</th>
       <th>Days left</th>
+      {% if user.is_authenticated and user.role == 'manager' %}
+      <th>Actions</th>
+      {% endif %}
     </tr>
   </thead>
   <tbody>
@@ -35,11 +38,16 @@
     <tr class="{% if ins.days_left > 10 %}table-success{% elif ins.days_left > 3 %}table-warning{% else %}table-danger{% endif %}">
       <td>{{ ins.title }}</td>
       <td>{{ ins.description }}</td>
-      <td>{{ ins.due_date }}</td>
+      <td>{{ ins.due_date|date:"d M Y" }}</td>
       <td>{{ ins.days_left }}</td>
+      {% if user.is_authenticated and user.role == 'manager' %}
+      <td>
+        <a href="{% url 'inspection_delete' ins.pk %}" class="btn btn-danger btn-sm"><img src="{% static 'icons/delete.svg' %}" class="icon me-1" alt="Delete">Delete</a>
+      </td>
+      {% endif %}
     </tr>
     {% empty %}
-    <tr><td colspan="4">No inspections.</td></tr>
+    <tr><td colspan="{% if user.is_authenticated and user.role == 'manager' %}5{% else %}4{% endif %}">No inspections.</td></tr>
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- allow managers to delete inspections through a new delete view
- show delete button beside inspections only for managers and format dates in English

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689133a15a8c8328980ce53c672ba745