### PR TITLE
Blue nav icons with brand hover scaling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -22,14 +22,12 @@ body {
 
 .navbar-brand {
   font-weight: 600;
-}
-
-.navbar-brand span {
-  display: inline-block;
+  display: flex;
+  align-items: center;
   transition: transform 0.2s ease;
 }
 
-.navbar-brand:hover span {
+.navbar-brand:hover {
   transform: scale(1.05);
 }
 
@@ -99,9 +97,13 @@ body {
 }
 
 .navbar .nav-link {
-  color: #333333;
+  color: #000000;
   padding: 10px 16px;
   transition: transform 0.2s ease;
+}
+
+.navbar .nav-link .icon {
+  color: #0d6efd;
 }
 
 .navbar .nav-link:hover {

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
         </li>
         <li class="nav-item">
           <a class="nav-link d-flex align-items-center" href="{% url 'suggestion_history' %}">
-            <i class="fa-solid fa-clock-rotate-left me-2 icon" style="color: black;"></i> History
+            <i class="fa-solid fa-clock-rotate-left me-2 icon"></i> History
           </a>
         </li>
         {% if user.role == 'manager' %}


### PR DESCRIPTION
## Summary
- color navigation link icons blue while keeping text black
- ensure factory icon and text scale together on brand hover

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6891344797f88328add71ea9684a2536