### PR TITLE
Display brand name in black with blue icon

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,13 +25,13 @@ body {
   font-weight: 600;
   display: flex;
   align-items: center;
-  color: #0d6efd;
+  color: #000000;
   transition: color 0.2s ease, transform 0.2s ease;
 }
 
 .navbar-brand:hover {
   transform: scale(1.05);
-  color: #0b5ed7;
+  color: #000000;
 }
 
 .navbar-brand img {
@@ -43,7 +43,7 @@ body {
   font-size: 32px;
   line-height: 1;
   vertical-align: middle;
-  color: inherit;
+  color: #0d6efd;
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- set navbar brand text color to black while keeping the icon blue

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68913e69c398832893d429eeb36684a6