### PR TITLE
feat: separate inspections history page

### DIFF
--- a/inspections/urls.py
+++ b/inspections/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path('', views.inspection_list, name='inspection_list'),
+    path('history/', views.inspection_history, name='inspection_history'),
     path('<int:pk>/check/', views.inspection_check, name='inspection_check'),
     path('<int:pk>/delete/', views.InspectionDeleteView.as_view(), name='inspection_delete'),
 ]

--- a/inspections/views.py
+++ b/inspections/views.py
@@ -27,7 +27,6 @@ def inspection_list(request):
             return redirect("inspection_list")
 
     inspections = Inspection.objects.filter(created_by=request.user, checked=False).order_by("due_date")
-    history = Inspection.objects.filter(created_by=request.user, checked=True).order_by("due_date")
     notifications = [
         {
             "title": i.title,
@@ -37,7 +36,7 @@ def inspection_list(request):
         for i in inspections
         if i.days_left <= 10
     ]
-    context = {"inspections": inspections, "history": history, "notifications": notifications}
+    context = {"inspections": inspections, "notifications": notifications}
     return render(request, "inspections/list.html", context)
 
 
@@ -50,6 +49,15 @@ def inspection_check(request, pk):
         inspection.checked = True
         inspection.save()
     return redirect("inspection_list")
+
+
+@login_required
+def inspection_history(request):
+    if getattr(request.user, "role", None) != "manager":
+        return redirect("index")
+    history = Inspection.objects.filter(created_by=request.user, checked=True).order_by("due_date")
+    context = {"history": history}
+    return render(request, "inspections/history.html", context)
 
 
 class InspectionDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,6 +40,11 @@
             <img src="{% static 'icons/clipboard-check.svg' %}" class="icon me-2" alt="Inspections"> Inspections
           </a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link d-flex align-items-center" href="{% url 'inspection_history' %}">
+            <i class="fa-solid fa-clock-rotate-left me-2 icon" style="color: #000000ad;"></i> Inspections History
+          </a>
+        </li>
         {% endif %}
       </ul>
       {% endif %}

--- a/templates/inspections/history.html
+++ b/templates/inspections/history.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Inspections History - FactoryApp{% endblock %}
+
+{% block content %}
+<h2>Inspections History</h2>
+<div class="list-group">
+  {% for ins in history %}
+  <div class="card-style mb-3 d-flex justify-content-between align-items-center history-item">
+    <div>
+      <p class="mb-1">{{ ins.title }}</p>
+      <small class="text-muted">{{ ins.description }}</small>
+    </div>
+    <a href="{% url 'inspection_delete' ins.pk %}" class="btn btn-danger btn-sm"><img src="{% static 'icons/delete.svg' %}" class="icon me-1" alt="Delete">Delete</a>
+  </div>
+  {% empty %}
+  <p>No completed inspections.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/templates/inspections/list.html
+++ b/templates/inspections/list.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col-md-6">
+  <div class="col-12">
     <h2>Inspections</h2>
     <div class="mb-4">
       <form method="post" class="card-style">
@@ -55,25 +55,9 @@
         <tr><td colspan="{% if user.is_authenticated and user.role == 'manager' %}5{% else %}4{% endif %}">No inspections.</td></tr>
         {% endfor %}
       </tbody>
-    </table>
-  </div>
-  <div class="col-md-6">
-    <h2>Inspections History</h2>
-    <div class="list-group">
-      {% for ins in history %}
-      <div class="card-style mb-3 d-flex justify-content-between align-items-center history-item">
-        <div>
-          <p class="mb-1">{{ ins.title }}</p>
-          <small class="text-muted">{{ ins.description }}</small>
-        </div>
-        <a href="{% url 'inspection_delete' ins.pk %}" class="btn btn-danger btn-sm"><img src="{% static 'icons/delete.svg' %}" class="icon me-1" alt="Delete">Delete</a>
-      </div>
-      {% empty %}
-      <p>No completed inspections.</p>
-      {% endfor %}
+      </table>
     </div>
   </div>
-</div>
 
 <div id="toast-container" class="position-fixed bottom-0 end-0 p-3" style="z-index: 11"></div>
 <script>


### PR DESCRIPTION
## Summary
- remove inline inspections history list from inspections page
- add dedicated inspections history page for managers
- expose inspections history in navbar for managers

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891443e0c108328acf1da7d92a14fad