### PR TITLE
Improve profile layout with contact details

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -67,8 +67,8 @@ body {
 }
 
 .profile-pic-large {
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
   border-radius: 50%;
   object-fit: cover;
 }
@@ -158,6 +158,20 @@ body {
   background-color: #f0f0f0;
   border-radius: 4px;
   transform: scale(1.02);
+}
+
+
+.profile-section {
+  background-color: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  padding: 20px;
+}
+
+.profile-username {
+  font-size: 1.5rem;
+  font-weight: 700;
 }
 
 

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -2,10 +2,11 @@
 {% block title %}Profile - FactoryApp{% endblock %}
 {% block content %}
 <h1 class="text-center mb-4">Profile</h1>
-<div class="d-flex flex-column align-items-center">
-  <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic-large mb-3" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
-  <p><strong>Username:</strong> {{ user.username }}</p>
-  <p><strong>Email:</strong> {{ user.email|default:"N/A" }}</p>
-  <p><strong>Role:</strong> {{ user.get_role_display }}</p>
+<div class="profile-section d-flex flex-column align-items-center">
+  <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic-large mb-2" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
+  <h2 class="profile-username mb-2">{{ user.username }}</h2>
+  <p class="mb-1"><span class="text-muted small">email for contact:</span> {{ user.email }}</p>
+  <p class="text-muted small mb-0">{{ user.get_role_display }}</p>
 </div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- style profile section with background, border, and shadow
- reduce avatar size and highlight username
- show registered email with contact label and role

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891486340ec8328912faf21e2e2c15c