### PR TITLE
Add subtle hover effect to suggestions send button

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -149,6 +149,10 @@ body {
   transform: scale(1.1);
 }
 
+.suggestion-send-btn:hover {
+  transform: scale(1.03);
+}
+
 
 .history-item {
   transition: transform 0.2s ease;

--- a/templates/suggestions/list.html
+++ b/templates/suggestions/list.html
@@ -11,7 +11,7 @@
     {% csrf_token %}
     <div class="input-group">
       <textarea name="text" class="form-control" placeholder="Enter suggestion..."></textarea>
-      <button class="btn btn-primary" type="submit"><img src="{% static 'icons/add.svg' %}" class="icon me-1" alt="Add">Send</button>
+      <button class="btn btn-primary suggestion-send-btn" type="submit"><img src="{% static 'icons/add.svg' %}" class="icon me-1" alt="Add">Send</button>
     </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- gently scale the suggestions send button on hover

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689148cbfe3c83289b115d7e6b12fb77