### PR TITLE
Use default avatar when profile picture missing

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,5 +1,6 @@
-from django.db import models
+from django.conf import settings
 from django.contrib.auth.models import AbstractUser
+from django.db import models
 
 class CustomUser(AbstractUser):
     class RoleChoices(models.TextChoices):
@@ -14,6 +15,11 @@ class CustomUser(AbstractUser):
     profile_picture = models.CharField(
         max_length=255,
         blank=True,
-        default="/static/icons/default_avatar.svg",
+        default=settings.DEFAULT_AVATAR_URL,
     )
+
+    @property
+    def profile_image_url(self) -> str:
+        """Return the user's profile image or the default avatar."""
+        return self.profile_picture or settings.DEFAULT_AVATAR_URL
 

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,20 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+
+class ProfileImageURLTests(TestCase):
+    def test_returns_default_when_blank(self):
+        User = get_user_model()
+        user = User.objects.create_user(
+            username="alice", password="password", profile_picture=""
+        )
+        self.assertEqual(user.profile_image_url, settings.DEFAULT_AVATAR_URL)
+
+    def test_returns_custom_url_when_set(self):
+        User = get_user_model()
+        url = "/static/icons/custom.svg"
+        user = User.objects.create_user(
+            username="bob", password="password", profile_picture=url
+        )
+        self.assertEqual(user.profile_image_url, url)

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="text-center mb-4">Profile</h1>
 <div class="profile-section d-flex flex-column align-items-center">
-  <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic-large mb-2" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
+  <img src="{{ user.profile_image_url }}" alt="Avatar" class="profile-pic-large mb-2" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
   <h2 class="profile-username mb-2">{{ user.username }}</h2>
   <p class="mb-1"><span class="text-muted small">email for contact:</span> {{ user.email }}</p>
   <p class="text-muted small mb-0">{{ user.get_role_display }}</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
     <div class="ms-auto me-3 d-flex align-items-center">
       {% if user.is_authenticated %}
         <a href="{% url 'view_profile' %}" class="d-flex align-items-center profile-link me-2">
-          <img src="{{ user.profile_picture|default:DEFAULT_AVATAR_URL }}" alt="Avatar" class="profile-pic" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
+          <img src="{{ user.profile_image_url }}" alt="Avatar" class="profile-pic" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
         </a>
         <div class="dropdown profile-menu">
           <span class="profile-link" id="profileDropdown">{{ user.username }}</span>


### PR DESCRIPTION
## Summary
- expose `profile_image_url` property on `CustomUser` so missing pictures fall back to the default avatar
- use `profile_image_url` in templates
- add tests for `profile_image_url`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68914efa82a8832883f44b7065661949