### PR TITLE
Add profile picture helper text to registration form

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -38,6 +38,7 @@ class RegistrationForm(UserCreationForm):
             validate_image_file,
         ],
         widget=forms.FileInput(),
+        help_text="If you don't upload a photo, your profile picture will be set to default.",
     )
 
     class Meta:

--- a/templates/register.html
+++ b/templates/register.html
@@ -79,6 +79,7 @@
         <div class="mb-3">
             {{ form.profile_picture.label_tag }}
             {{ form.profile_picture }}
+            <div class="form-text">{{ form.profile_picture.help_text }}</div>
             {% if form.profile_picture.errors %}
                 <ul class="text-danger">
                     {% for error in form.profile_picture.errors %}


### PR DESCRIPTION
## Summary
- show helper text under profile picture upload field
- document default behavior when no photo is uploaded

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68923949ac048328b37b675476a48f2b