### PR TITLE
Add manager-only deletion for departments and machines

### DIFF
--- a/common/tests.py
+++ b/common/tests.py
@@ -1,3 +1,67 @@
+"""Tests for department and machine list views."""
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Department, Machine
+
+
+class DepartmentMachineViewTests(TestCase):
+    def setUp(self) -> None:
+        User = get_user_model()
+        self.manager = User.objects.create_user(
+            username="manager", password="pass", role="manager"
+        )
+        self.worker = User.objects.create_user(
+            username="worker", password="pass", role="worker"
+        )
+        self.department = Department.objects.create(name="Assembly")
+        self.machine = Machine.objects.create(
+            name="Lathe", serial_number="SN123", department=self.department
+        )
+
+    def test_worker_only_sees_lists(self):
+        self.client.login(username="worker", password="pass")
+        dept_response = self.client.get(reverse("department_list"))
+        self.assertContains(dept_response, "Assembly")
+        self.assertNotContains(dept_response, "Add Department")
+        self.assertNotContains(
+            dept_response, reverse("delete_department", args=[self.department.id])
+        )
+
+        machine_response = self.client.get(reverse("machine_list"))
+        self.assertContains(machine_response, "Lathe")
+        self.assertNotContains(machine_response, "Add Machine")
+        self.assertNotContains(
+            machine_response, reverse("delete_machine", args=[self.machine.id])
+        )
+
+    def test_manager_sees_forms_and_delete_buttons(self):
+        self.client.login(username="manager", password="pass")
+        dept_response = self.client.get(reverse("department_list"))
+        self.assertContains(dept_response, "Add Department")
+        self.assertContains(
+            dept_response, reverse("delete_department", args=[self.department.id])
+        )
+
+        machine_response = self.client.get(reverse("machine_list"))
+        self.assertContains(machine_response, "Add Machine")
+        self.assertContains(
+            machine_response, reverse("delete_machine", args=[self.machine.id])
+        )
+
+    def test_manager_can_delete(self):
+        self.client.login(username="manager", password="pass")
+        self.client.post(reverse("delete_machine", args=[self.machine.id]))
+        self.assertFalse(Machine.objects.filter(id=self.machine.id).exists())
+        self.client.post(reverse("delete_department", args=[self.department.id]))
+        self.assertFalse(Department.objects.filter(id=self.department.id).exists())
+
+    def test_worker_cannot_delete(self):
+        self.client.login(username="worker", password="pass")
+        self.client.post(reverse("delete_machine", args=[self.machine.id]))
+        self.client.post(reverse("delete_department", args=[self.department.id]))
+        self.assertTrue(Machine.objects.filter(id=self.machine.id).exists())
+        self.assertTrue(Department.objects.filter(id=self.department.id).exists())
+

--- a/common/urls.py
+++ b/common/urls.py
@@ -1,9 +1,17 @@
 from django.urls import path
 
-from .views import HomeView, department_list, machine_list
+from .views import (
+    HomeView,
+    department_list,
+    delete_department,
+    delete_machine,
+    machine_list,
+)
 
 urlpatterns = [
     path('', HomeView.as_view(), name='index'),
     path('departments/', department_list, name='department_list'),
+    path('departments/<int:pk>/delete/', delete_department, name='delete_department'),
     path('machines/', machine_list, name='machine_list'),
+    path('machines/<int:pk>/delete/', delete_machine, name='delete_machine'),
 ]

--- a/common/views.py
+++ b/common/views.py
@@ -2,7 +2,7 @@
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import TemplateView
 
 from .forms import DepartmentForm, MachineForm
@@ -16,8 +16,9 @@ class HomeView(TemplateView):
 def department_list(request):
     """List departments and allow managers to create new ones."""
 
-    form = DepartmentForm(request.POST or None)
-    if request.method == "POST" and getattr(request.user, "role", None) == "manager":
+    is_manager = getattr(request.user, "role", None) == "manager"
+    form = DepartmentForm(request.POST or None) if is_manager else None
+    if request.method == "POST" and is_manager:
         if form.is_valid():
             form.save()
             messages.success(request, "Department added successfully.")
@@ -32,8 +33,9 @@ def department_list(request):
 def machine_list(request):
     """List machines and allow managers to create them."""
 
-    form = MachineForm(request.POST or None)
-    if request.method == "POST" and getattr(request.user, "role", None) == "manager":
+    is_manager = getattr(request.user, "role", None) == "manager"
+    form = MachineForm(request.POST or None) if is_manager else None
+    if request.method == "POST" and is_manager:
         if form.is_valid():
             form.save()
             messages.success(request, "Machine added successfully.")
@@ -42,3 +44,29 @@ def machine_list(request):
     machines = Machine.objects.select_related("department").all().order_by("name")
     context = {"form": form, "machines": machines}
     return render(request, "common/machines.html", context)
+
+
+@login_required
+def delete_department(request, pk):
+    """Delete a department (managers only)."""
+
+    if getattr(request.user, "role", None) != "manager":
+        return redirect("department_list")
+    department = get_object_or_404(Department, pk=pk)
+    if request.method == "POST":
+        department.delete()
+        messages.success(request, "Department deleted successfully.")
+    return redirect("department_list")
+
+
+@login_required
+def delete_machine(request, pk):
+    """Delete a machine (managers only)."""
+
+    if getattr(request.user, "role", None) != "manager":
+        return redirect("machine_list")
+    machine = get_object_or_404(Machine, pk=pk)
+    if request.method == "POST":
+        machine.delete()
+        messages.success(request, "Machine deleted successfully.")
+    return redirect("machine_list")

--- a/templates/common/departments.html
+++ b/templates/common/departments.html
@@ -13,8 +13,16 @@
 
 <ul class="list-group">
     {% for department in departments %}
-    <li class="list-group-item">
-        <strong>{{ department.name }}</strong>{% if department.description %} - {{ department.description }}{% endif %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>
+            <strong>{{ department.name }}</strong>{% if department.description %} - {{ department.description }}{% endif %}
+        </span>
+        {% if user.role == 'manager' %}
+        <form method="post" action="{% url 'delete_department' department.id %}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+        </form>
+        {% endif %}
     </li>
     {% empty %}
     <li class="list-group-item">No departments available.</li>

--- a/templates/common/machines.html
+++ b/templates/common/machines.html
@@ -18,6 +18,9 @@
             <th>Serial Number</th>
             <th>Department</th>
             <th>Last Maintenance</th>
+            {% if user.role == 'manager' %}
+            <th></th>
+            {% endif %}
         </tr>
     </thead>
     <tbody>
@@ -27,9 +30,17 @@
             <td>{{ machine.serial_number }}</td>
             <td>{{ machine.department.name }}</td>
             <td>{{ machine.last_maintenance|date:'Y-m-d' }}</td>
+            {% if user.role == 'manager' %}
+            <td>
+                <form method="post" action="{% url 'delete_machine' machine.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
+            </td>
+            {% endif %}
         </tr>
         {% empty %}
-        <tr><td colspan="4">No machines available.</td></tr>
+        <tr><td colspan="{% if user.role == 'manager' %}5{% else %}4{% endif %}">No machines available.</td></tr>
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- add delete views and buttons for departments and machines (managers only)
- hide department/machine creation forms from workers
- add tests for manager vs worker permissions

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6892560f17c48328a49fd4976c006b72