### PR TITLE
Remove email references from profile pages

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -109,7 +109,7 @@ class EditProfileForm(forms.ModelForm):
 
     class Meta:
         model = CustomUser
-        fields = ("username", "email", "profile_picture")
+        fields = ("username", "profile_picture")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/templates/accounts/edit_profile.html
+++ b/templates/accounts/edit_profile.html
@@ -21,18 +21,6 @@
         </div>
 
         <div class="mb-3">
-            {{ form.email.label_tag }}
-            {{ form.email }}
-            {% if form.email.errors %}
-                <ul class="text-danger">
-                    {% for error in form.email.errors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        </div>
-
-        <div class="mb-3">
             {{ form.profile_picture.label_tag }}
             {{ form.profile_picture }}
             {% if form.profile_picture.errors %}

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -5,7 +5,6 @@
 <div class="profile-section d-flex flex-column align-items-center">
   <img src="{{ user.profile_image_url }}" alt="Avatar" class="profile-pic-large mb-2" onerror="this.onerror=null;this.src='{{ DEFAULT_AVATAR_URL }}';">
   <h2 class="profile-username mb-2">{{ user.username }}</h2>
-  <p class="mb-1"><span class="text-muted small">email for contact:</span> {{ user.email }}</p>
   <p class="text-muted small mb-0">{{ user.get_role_display }}</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- drop email field from profile edit form
- stop displaying user email on profile page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689267d5e08c8328ad748654b2f5ec90